### PR TITLE
Open Application root folder instead of the Library folder

### DIFF
--- a/SimSim/AppDelegate.m
+++ b/SimSim/AppDelegate.m
@@ -225,7 +225,7 @@
                                applicationBundleName, applicationVersion];
 
             NSString* applicationContentPath =
-            [NSString stringWithFormat:@"%@/Library/Developer/CoreSimulator/Devices/%@/data/Containers/Data/Application/%@/Library/",
+            [NSString stringWithFormat:@"%@/Library/Developer/CoreSimulator/Devices/%@/data/Containers/Data/Application/%@/",
              NSHomeDirectory(), simulatorUUID, appDataUUID];
 
             


### PR DESCRIPTION
Jump directly into the root folder of the application to also get the Documents folder at the root level.
