### PR TITLE
added Commander One PRO (from App Store) availability check

### DIFF
--- a/SimSim/FileManagerSupport/CommanderOne.m
+++ b/SimSim/FileManagerSupport/CommanderOne.m
@@ -12,9 +12,9 @@
     NSFileManager* fileManager = [NSFileManager defaultManager];
 
     // Check for App Store version
-    NSString* applicationsPath = @"/Applications/Commander One.app";
-    BOOL isApplicationExist = [fileManager fileExistsAtPath:applicationsPath];
-    if (isApplicationExist)
+    BOOL isApplicationExist = [fileManager fileExistsAtPath:@"/Applications/Commander One.app"];
+    BOOL isApplicationProExist = [fileManager fileExistsAtPath:@"/Applications/Commander One PRO.app"];
+    if (isApplicationExist || isApplicationProExist)
     {
         return YES;
     }


### PR DESCRIPTION
I don't know the bundle id for the downloaded PRO version, but here's a check for the App Store one