### PR TITLE
Added support to search realm DB files and open them

### DIFF
--- a/SimSim.xcodeproj/project.pbxproj
+++ b/SimSim.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		9AE0DDA41DAE4852000029EC /* empty_icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 9AE0DDA31DAE4852000029EC /* empty_icon.png */; };
 		BE7C115219E56B4F001A6220 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = BE7C115119E56B4F001A6220 /* main.m */; };
 		BE7C115519E56B4F001A6220 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = BE7C115419E56B4F001A6220 /* AppDelegate.m */; };
+		EAE2ADCE1EAF7207009D3F39 /* FileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = EAE2ADCD1EAF7207009D3F39 /* FileManager.m */; };
+		EAE2ADD21EB07943009D3F39 /* Realm.m in Sources */ = {isa = PBXBuildFile; fileRef = EAE2ADD11EB07943009D3F39 /* Realm.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -30,6 +32,10 @@
 		BE7C115119E56B4F001A6220 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		BE7C115319E56B4F001A6220 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		BE7C115419E56B4F001A6220 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		EAE2ADCC1EAF7207009D3F39 /* FileManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FileManager.h; path = Libs/FileManager.h; sourceTree = "<group>"; };
+		EAE2ADCD1EAF7207009D3F39 /* FileManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FileManager.m; path = Libs/FileManager.m; sourceTree = "<group>"; };
+		EAE2ADD01EB07943009D3F39 /* Realm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Realm.h; sourceTree = "<group>"; };
+		EAE2ADD11EB07943009D3F39 /* Realm.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Realm.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -82,6 +88,8 @@
 		BE7C114E19E56B4F001A6220 /* SimSim */ = {
 			isa = PBXGroup;
 			children = (
+				EAE2ADCB1EAF71E9009D3F39 /* Libs */,
+				EA028AAB1EAF40A5008ECFA9 /* Modules */,
 				BE7C115319E56B4F001A6220 /* AppDelegate.h */,
 				BE7C115419E56B4F001A6220 /* AppDelegate.m */,
 				7C4BC6391CCA94D200C72BA1 /* Settings.h */,
@@ -100,6 +108,33 @@
 				BE7C115119E56B4F001A6220 /* main.m */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		EA028AAB1EAF40A5008ECFA9 /* Modules */ = {
+			isa = PBXGroup;
+			children = (
+				EAE2ADCF1EB07943009D3F39 /* Realm */,
+			);
+			name = Modules;
+			sourceTree = "<group>";
+		};
+		EAE2ADCB1EAF71E9009D3F39 /* Libs */ = {
+			isa = PBXGroup;
+			children = (
+				EAE2ADCC1EAF7207009D3F39 /* FileManager.h */,
+				EAE2ADCD1EAF7207009D3F39 /* FileManager.m */,
+			);
+			name = Libs;
+			sourceTree = "<group>";
+		};
+		EAE2ADCF1EB07943009D3F39 /* Realm */ = {
+			isa = PBXGroup;
+			children = (
+				EAE2ADD01EB07943009D3F39 /* Realm.h */,
+				EAE2ADD11EB07943009D3F39 /* Realm.m */,
+			);
+			name = Realm;
+			path = Modules/Realm;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -175,7 +210,9 @@
 				BE7C115519E56B4F001A6220 /* AppDelegate.m in Sources */,
 				BE7C115219E56B4F001A6220 /* main.m in Sources */,
 				7C4BC63B1CCA94D200C72BA1 /* Settings.m in Sources */,
+				EAE2ADD21EB07943009D3F39 /* Realm.m in Sources */,
 				13F9C8331B0C2C982C9CA14F /* CommanderOne.m in Sources */,
+				EAE2ADCE1EAF7207009D3F39 /* FileManager.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SimSim/Libs/FileManager.h
+++ b/SimSim/Libs/FileManager.h
@@ -1,0 +1,20 @@
+//
+//  FileManager.h
+//  SimSim
+//
+//  Created by Jesus Lopez on 25/04/2017.
+//  Copyright © 2017 DaniilSmelov. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#define KEY_FILE                    @"file"
+#define KEY_MODIFICATION_DATE       @"modificationDate"
+#define KEY_FILE_TYPE               @"fileType"
+
+@interface FileManager : NSObject
+
++ (NSArray *) getSortedFilesFromFolder:(NSString *)folderPath;
++ (NSString *) getApplicationFolderFromPath:(NSString *)folderPath;
+
+@end

--- a/SimSim/Libs/FileManager.m
+++ b/SimSim/Libs/FileManager.m
@@ -1,0 +1,67 @@
+//
+//  FileManager.m
+//  SimSim
+//
+//  Created by Jesus Lopez on 25/04/2017.
+//  Copyright © 2017 DaniilSmelov. All rights reserved.
+//
+
+#import "FileManager.h"
+
+@implementation FileManager
+
++ (NSArray*) getSortedFilesFromFolder:(NSString*)folderPath
+{
+    NSArray* filesArray = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:folderPath error:nil];
+    
+    // sort by creation date
+    NSMutableArray* filesAndProperties = [NSMutableArray arrayWithCapacity:filesArray.count];
+    
+    for (NSString* file in filesArray)
+    {
+        if (![file isEqualToString:@".DS_Store"])
+        {
+            NSString* filePath = [folderPath stringByAppendingPathComponent:file];
+            NSDictionary* properties = [[NSFileManager defaultManager] attributesOfItemAtPath:filePath error:nil];
+            NSDate* modificationDate = properties[NSFileModificationDate];
+            NSString *fileType = properties[NSFileType];
+            
+            [filesAndProperties addObject:@
+             {
+                 KEY_FILE              : file,
+                 KEY_MODIFICATION_DATE : modificationDate,
+                 KEY_FILE_TYPE         : fileType
+             }];
+        }
+    }
+    
+    // Sort using a block - order inverted as we want latest date first
+    NSArray* sortedFiles = [filesAndProperties sortedArrayUsingComparator:^(NSDictionary* path1, NSDictionary* path2)
+                            {
+                                NSComparisonResult comp = [path1[@"modificationDate"] compare:path2[@"modificationDate"]];
+                                // invert ordering
+                                if (comp == NSOrderedDescending)
+                                {
+                                    comp = NSOrderedAscending;
+                                }
+                                else if (comp == NSOrderedAscending)
+                                {
+                                    comp = NSOrderedDescending;
+                                }
+                                return comp;
+                            }];
+    
+    return sortedFiles;
+}
+
+//----------------------------------------------------------------------------
++ (NSString*) getApplicationFolderFromPath:(NSString*)folderPath
+{
+    NSArray* filesArray = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:folderPath error:nil];
+    NSPredicate* predicate = [NSPredicate predicateWithFormat:@"SELF EndsWith '.app'"];
+    filesArray = [filesArray filteredArrayUsingPredicate:predicate];
+    
+    return filesArray[0];
+}
+
+@end

--- a/SimSim/Modules/Realm/Realm.h
+++ b/SimSim/Modules/Realm/Realm.h
@@ -1,0 +1,23 @@
+//
+//  Realm.h
+//  SimSim
+//
+//  Created by Jesus Lopez on 25/04/2017.
+//  Copyright © 2017 DaniilSmelov. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class NSMenu;
+
+@interface Realm : NSObject
+
++ (BOOL)isRealmBrowserAvailable;
++ (NSString *__nonnull)applicationPath;
++ (BOOL)isRealmAvailableForPath:(NSString *__nonnull)aPath;
++ (void)openInRealmBrowser:(NSString *__nonnull)aPath;
+
+
+- (NSMenu *__nullable)generateRealmMenuForPath:(NSString *__nonnull)aPath;
+
+@end

--- a/SimSim/Modules/Realm/Realm.m
+++ b/SimSim/Modules/Realm/Realm.m
@@ -1,0 +1,95 @@
+//
+//  Realm.m
+//  SimSim
+//
+//  Created by Jesus Lopez on 25/04/2017.
+//  Copyright © 2017 DaniilSmelov. All rights reserved.
+//
+
+#import "Realm.h"
+#import <Cocoa/Cocoa.h>
+#import "FileManager.h"
+
+#define PATH_REALM_FILES        @"Library/Caches"
+#define REALM_APP_NAME          @"Realm Browser"
+#define REALM_APP_URL           @"http://itunes.apple.com/es/app/realm-browser/id1007457278"
+
+@implementation Realm
+
+
+- (NSMenu *)generateRealmMenuForPath:(NSString *)aPath {
+    
+    NSMenu* menuRealm = [[NSMenu alloc] initWithTitle:@"Realm Browser"];
+    [menuRealm setAutoenablesItems:NO];
+    NSArray *realmFiles = [[self class] findRealmFiles:aPath];
+    
+    BOOL isRealmBrowserInstalled = [[self class] isRealmBrowserAvailable];
+    
+    for (NSString *fileName in realmFiles) {
+        NSMenuItem* menuItem = [[NSMenuItem alloc] initWithTitle:fileName action:@selector(openRealmFile:) keyEquivalent:@""];
+        [menuItem setTarget:self];
+        [menuItem setRepresentedObject:[NSString stringWithFormat:@"%@/%@/%@", aPath, PATH_REALM_FILES, fileName]];
+        [menuItem setEnabled:isRealmBrowserInstalled];;
+        [menuRealm addItem:menuItem];
+    }
+    
+    if (!isRealmBrowserInstalled) {
+        NSMenuItem* realmBrowserInstallMenuItem = [[NSMenuItem alloc] initWithTitle:@"Install Realm Browser" action:@selector(installRealmBrowser:) keyEquivalent:@""];
+        [realmBrowserInstallMenuItem setTarget:self];
+        [realmBrowserInstallMenuItem setRepresentedObject:REALM_APP_URL];
+        [menuRealm addItem:realmBrowserInstallMenuItem];
+    }
+    
+    return menuRealm;
+}
+
+
+- (void)openRealmFile:(id)sender {
+    [[self class] openInRealmBrowser:[sender representedObject]];
+}
+
+- (void)installRealmBrowser:(id)sender {
+    [self openUrl:[sender representedObject]];
+}
+
+- (void)openUrl:(NSString *)aUrl {
+    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:aUrl]];
+}
+
+#pragma mark - Statics methods
+
++ (NSArray *)findRealmFiles:(NSString *)aPath {
+    NSMutableArray *files = [NSMutableArray new];
+    NSArray *allFiles = [FileManager getSortedFilesFromFolder:[NSString stringWithFormat:@"%@/%@", aPath, PATH_REALM_FILES]];
+    for (NSDictionary *file in allFiles) {
+        [files addObject:file[KEY_FILE]];
+    }
+    return [self removeNonRealmObject:files];
+}
+
++ (NSArray *)removeNonRealmObject:(NSArray *)allFiles {
+    NSPredicate *endsRealm = [NSPredicate predicateWithFormat:@"self ENDSWITH '.realm'"];
+    return [allFiles filteredArrayUsingPredicate:endsRealm];
+}
+
+#pragma mark - Public Statics methods
+
++ (BOOL)isRealmBrowserAvailable {
+    NSFileManager* fileManager = [NSFileManager defaultManager];
+    return [fileManager fileExistsAtPath:[[self class] applicationPath]];
+}
+
++ (NSString *)applicationPath {
+    return [NSString stringWithFormat:@"/Applications/%@.app", REALM_APP_NAME];
+}
+
++ (BOOL)isRealmAvailableForPath:(NSString *)aPath {
+    NSArray *realmFiles = [[self class] findRealmFiles:aPath];
+    return (realmFiles != nil && [realmFiles count] > 0);
+}
+
++ (void)openInRealmBrowser:(NSString *)aPath {
+    [[NSWorkspace sharedWorkspace] openFile:aPath withApplication:REALM_APP_NAME];
+}
+
+@end


### PR DESCRIPTION
I have added support to explore Realm DB files on the menu, and allow to open the realm DB file on click.
- If Realm DB files are not found on application folder, Realm menu item is not shown.
- If Realm Browser is not installed, menu items are disabled by default, only one menu item to install it is enabled.
![Realm Browser not found](https://cloud.githubusercontent.com/assets/7817064/25423379/c115945e-2a64-11e7-9a39-771f9352a876.png)

- If Realm Browser is installed, menu items are enabled and install menu item does not appear.
![Realm Browser Installed]
![Realm Browser Installed](https://cloud.githubusercontent.com/assets/7817064/25423378/c11436ae-2a64-11e7-94c6-66efe9af390c.png)

I have create some structure folder with the idea to allow further development as modules, also I have done a bit of refactor to re use some code and void duplicate it.

If you find something strange let me know :) @dsmelov 

