### PR TITLE
Improved RealmModule

### DIFF
--- a/SimSim/AppDelegate.m
+++ b/SimSim/AppDelegate.m
@@ -131,16 +131,12 @@
         if (self.realmModule == nil) {
             self.realmModule = [Realm new];
         }
-        
-        NSMenuItem* realmMenuItem = [[NSMenuItem alloc] initWithTitle:@"Realm" action:nil keyEquivalent:[hotkey stringValue]];
-        [realmMenuItem setRepresentedObject:path];
+
         icon = [[NSWorkspace sharedWorkspace] iconForFile:[Realm applicationPath]];
         [icon setSize: NSMakeSize(ACTION_ICON_SIZE, ACTION_ICON_SIZE)];
-        [realmMenuItem setImage:icon];
-        
-        [subMenu addItem:realmMenuItem];
-        [subMenu setSubmenu:[self.realmModule generateRealmMenuForPath:path] forItem:realmMenuItem];
-        
+
+        [self.realmModule generateRealmMenuForPath:path forMenu:subMenu withHotKey:hotkey icon:icon];
+
         hotkey = [NSNumber numberWithInt:[hotkey intValue] + 1];
     }
     

--- a/SimSim/Modules/Realm/Realm.h
+++ b/SimSim/Modules/Realm/Realm.h
@@ -18,6 +18,13 @@
 + (void)openInRealmBrowser:(NSString *__nonnull)aPath;
 
 
-- (NSMenu *__nullable)generateRealmMenuForPath:(NSString *__nonnull)aPath;
+- (void)generateRealmMenuForPath:(NSString *__nonnull)aPath forMenu:(NSMenu *_Nonnull)menu withHotKey:(NSNumber *_Nonnull)hotkey icon:(NSImage *_Nonnull)icon;
 
+@end
+
+@interface RealmFile : NSObject
+@property (assign) NSString * _Nonnull fileName;
+@property (assign) NSString * _Nonnull path;
+
+- (NSString *_Nonnull)fullPath;
 @end


### PR DESCRIPTION
In iOS, Realm uses the /Documents Folder as a default for the default.realm file, so I added this path to the "findRealmFiles" Method. simsim will now find all realm files in "Library/Caches" and "Documents".

I also improved the Menu for Realm. If there is only one realm file in the simulator, simsim will display no submenu with just one entry instead, you can click the realm-menu itself.

Multiple realm files:
<img width="636" alt="bildschirmfoto 2017-07-01 um 09 03 21" src="https://user-images.githubusercontent.com/4823365/27760454-ee99f9e4-5e47-11e7-96a0-a10f5638b24b.png">

Single realm file:
<img width="486" alt="bildschirmfoto 2017-07-01 um 09 03 58" src="https://user-images.githubusercontent.com/4823365/27760453-ee99beac-5e47-11e7-9bd0-60d8213a38ea.png">

No RealmBrowser installed:
<img width="489" alt="bildschirmfoto 2017-07-01 um 10 24 43" src="https://user-images.githubusercontent.com/4823365/27760455-ee9e1722-5e47-11e7-90d1-f629b6298b94.png">
