### PR TITLE
Fix for Issue#18

### DIFF
--- a/SimSim/AppDelegate.m
+++ b/SimSim/AppDelegate.m
@@ -424,6 +424,8 @@
         NSString* simulatorDetailsPath = [path stringByAppendingString:@"device.plist"];
         
         NSDictionary* properties = [NSDictionary dictionaryWithContentsOfFile:simulatorDetailsPath];
+
+        if (properties == nil) { continue; } // skip "empty" properties
         
         [simulatorProperties insertObject:properties atIndex:i]; // to be sure in index correlation
         i++;
@@ -524,7 +526,7 @@
     NSMutableArray* simulatorPaths = [self simulatorPaths];
     NSMutableArray* simulatorDetails = [self activeSimulatorProperties];
     
-    for (int i = 0; i < [simulatorPaths count]; i++)
+    for (int i = 0; i < [simulatorDetails count]; i++)
     {
         NSString* simulatorRootPath = [simulatorPaths objectAtIndex:i];
         NSDictionary* details = [simulatorDetails objectAtIndex:i];


### PR DESCRIPTION
simsim failed to show the "main"-menu if no apps were installed on any simulator, this is now fixed:
![image](https://user-images.githubusercontent.com/4823365/27915073-76988844-6265-11e7-910c-c199d9d8da31.png)
