### PR TITLE
Adds support for shared App Groups

### DIFF
--- a/SimSim.xcodeproj/project.pbxproj
+++ b/SimSim.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		13F9C8BD40BFC0BD5697F05F /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13F9C81FB41E59E5B1EF4FD9 /* Images.xcassets */; };
 		13F9C9CACDE21D1AB57BD94D /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 13F9CAF1018B8DF204603BAC /* MainMenu.xib */; };
+		21EF9E9D20E43AD500DE70C5 /* AppGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21EF9E9C20E43AD500DE70C5 /* AppGroup.swift */; };
+		21EF9EA120E443AB00DE70C5 /* Simulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21EF9EA020E443AB00DE70C5 /* Simulator.swift */; };
 		7C457F561FD9AD6F007E84B5 /* Application.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C457F551FD9AD6F007E84B5 /* Application.m */; };
 		7C4BC63B1CCA94D200C72BA1 /* Settings.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C4BC63A1CCA94D200C72BA1 /* Settings.m */; };
 		7CD93A731F7EBE3D00C4AA85 /* Simulator.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CD93A721F7EBE3D00C4AA85 /* Simulator.m */; };
@@ -25,6 +27,8 @@
 /* Begin PBXFileReference section */
 		13F9C038950463FE8C9CF8F9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = SimSim/Base.lproj/MainMenu.xib; sourceTree = SOURCE_ROOT; };
 		13F9C81FB41E59E5B1EF4FD9 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		21EF9E9C20E43AD500DE70C5 /* AppGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroup.swift; sourceTree = "<group>"; };
+		21EF9EA020E443AB00DE70C5 /* Simulator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Simulator.swift; sourceTree = "<group>"; };
 		7C457F541FD9AD6F007E84B5 /* Application.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Application.h; sourceTree = "<group>"; };
 		7C457F551FD9AD6F007E84B5 /* Application.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Application.m; sourceTree = "<group>"; };
 		7C4BC6391CCA94D200C72BA1 /* Settings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Settings.h; sourceTree = "<group>"; };
@@ -71,8 +75,10 @@
 			children = (
 				7CD93A711F7EBE3D00C4AA85 /* Simulator.h */,
 				7CD93A721F7EBE3D00C4AA85 /* Simulator.m */,
+				21EF9EA020E443AB00DE70C5 /* Simulator.swift */,
 				7C457F541FD9AD6F007E84B5 /* Application.h */,
 				7C457F551FD9AD6F007E84B5 /* Application.m */,
+				21EF9E9C20E43AD500DE70C5 /* AppGroup.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -193,7 +199,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				21EF9E9D20E43AD500DE70C5 /* AppGroup.swift in Sources */,
 				9A04C01A20851B350060BB4E /* Constants.swift in Sources */,
+				21EF9EA120E443AB00DE70C5 /* Simulator.swift in Sources */,
 				9A4FE78A2088D2A000158845 /* Application.swift in Sources */,
 				9A04C014208126C90060BB4E /* Menus.swift in Sources */,
 				9A4FE7842087C70500158845 /* Realm.swift in Sources */,

--- a/SimSim/Actions.swift
+++ b/SimSim/Actions.swift
@@ -124,11 +124,11 @@ class Actions: NSObject
     {
         guard let event = NSApp.currentEvent else { return }
         
-        if UInt8(event.modifierFlags.rawValue) & UInt8(NSAlternateKeyMask.rawValue) != 0
+        if event.modifierFlags.rawValue & NSAlternateKeyMask.rawValue != 0
         {
             Actions.open(inTerminal: sender)
         }
-        else if UInt8(event.modifierFlags.rawValue) & UInt8(NSControlKeyMask.rawValue) != 0
+        else if event.modifierFlags.rawValue & NSControlKeyMask.rawValue != 0
         {
             if Tools.commanderOneAvailable()
             {

--- a/SimSim/Entities/AppGroup.swift
+++ b/SimSim/Entities/AppGroup.swift
@@ -1,0 +1,42 @@
+//
+//  AppGroup.swift
+//  SimSim
+//
+
+import Foundation
+
+class AppGroup {
+    private let uuid: String
+    let path: String
+    let identifier: String
+
+    var isAppleAppGroup: Bool {
+        return identifier.starts(with: "com.apple") || identifier.starts(with: "group.com.apple")
+    }
+
+    private init(uuid: String, path: String, identifier: String) {
+        self.uuid = uuid
+        self.path = path
+        self.identifier = identifier
+    }
+
+    convenience init?(dictionary: [AnyHashable : Any], simulator: Simulator) {
+        guard let uuid = dictionary[Tools.Keys.fileName] as? String else {
+            return nil
+        }
+        
+        let path = simulator.pathForAppGroup(withUUID: uuid)
+
+        let plistPath = path + ".com.apple.mobile_container_manager.metadata.plist"
+        guard let plistData = try? Data(contentsOf: URL(fileURLWithPath: plistPath)) else {
+            return nil
+        }
+        guard let metadataPlist = try? PropertyListSerialization.propertyList(from: plistData, options: [], format: nil) as! [String: Any] else {
+            return nil
+        }
+
+        let identifier = metadataPlist["MCMMetadataIdentifier"] as! String
+
+        self.init(uuid: uuid, path: path, identifier: identifier)
+    }
+}

--- a/SimSim/Entities/Simulator.swift
+++ b/SimSim/Entities/Simulator.swift
@@ -1,0 +1,12 @@
+//
+//  Simulator.swift
+//  SimSim
+//
+
+import Foundation
+
+extension Simulator {
+    func pathForAppGroup(withUUID uuid: String) -> String {
+        return path + "data/Containers/Shared/AppGroup/\(uuid)/"
+    }
+}

--- a/SimSim/Menus.swift
+++ b/SimSim/Menus.swift
@@ -133,6 +133,18 @@ class Menus: NSObject
     }
 
     //----------------------------------------------------------------------------
+    class func add(appGroup: AppGroup, to menu: NSMenu)
+    {
+        let item = NSMenuItem(title: appGroup.identifier, action: #selector(Actions.openIn(withModifier:)), keyEquivalent: "\0")
+        item.target = Actions.self
+        item.representedObject = appGroup.path
+
+        self.addSubMenus(to: item, usingPath: appGroup.path)
+
+        menu.addItem(item)
+    }
+
+    //----------------------------------------------------------------------------
     class func addServiceItems(to menu: NSMenu)
     {
         let startAtLogin = NSMenuItem(title: Constants.Actions.login, action: #selector(Actions.handleStart(atLogin:)), keyEquivalent: "")
@@ -165,6 +177,7 @@ class Menus: NSObject
         for simulator in recentSimulators
         {
             let installedApplications = Tools.installedApps(on: simulator)!
+            let sharedAppGroups = Tools.sharedAppGroups(on: simulator)
             
             guard installedApplications.count != 0 else
             {
@@ -176,6 +189,7 @@ class Menus: NSObject
             simulatorMenuItem.isEnabled = false
             menu.addItem(simulatorMenuItem)
             addApplications(installedApplications, to: menu)
+            sharedAppGroups.forEach { add(appGroup: $0, to: menu) }
             simulatorsCount += 1
         
             if simulatorsCount >= Constants.maxRecentSimulators

--- a/SimSim/Tools.swift
+++ b/SimSim/Tools.swift
@@ -132,6 +132,16 @@ class Tools: NSObject
     }
 
     //----------------------------------------------------------------------------
+    class func sharedAppGroups(on simulator: Simulator) -> [AppGroup]
+    {
+        let appGroupsDataPath = (simulator.path)! + ("data/Containers/Shared/AppGroup/")
+        let appGroups = Tools.getSortedFiles(fromFolder: appGroupsDataPath)
+
+        return appGroups.compactMap({ AppGroup(dictionary: $0 as! [AnyHashable: Any], simulator: simulator) })
+            .filter { !$0.isAppleAppGroup }
+    }
+
+    //----------------------------------------------------------------------------
     class func commanderOneAvailable() -> Bool
     {
         let fileManager = FileManager.default

--- a/SimSim/Tools.swift
+++ b/SimSim/Tools.swift
@@ -155,7 +155,7 @@ class Tools: NSObject
     class func allFilesAt(path: String) -> [String]
     {
         let files = try? FileManager.default.contentsOfDirectory(atPath: path)
-        return files!
+        return files ?? []
     }
     
     //----------------------------------------------------------------------------


### PR DESCRIPTION
This change adds support for showing shared App Groups from simulators in the menu alongside applications.

App Groups provide a way to share data between extensions and other applications by the same developer or development team. See Adding an [App to an App Group](https://developer.apple.com/library/archive/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/EnablingAppSandbox.html#//apple_ref/doc/uid/TP40011195-CH4-SW19) for more details.

A few of the applications I work on use App Groups as the primary location for their data storage so it's very useful to be able to navigate to them directly.

This change also includes fixes for a few Swift related crashes I encountered.