### PR TITLE
Refactors getApplicationFolder class function

### DIFF
--- a/SimSim/Tools.swift
+++ b/SimSim/Tools.swift
@@ -222,10 +222,8 @@ class Tools: NSObject
     //----------------------------------------------------------------------------
     class func getApplicationFolder(fromPath folderPath: String) -> String
     {
-        var files = allFilesAt(path: folderPath)
-        let predicate = NSPredicate(format: "SELF EndsWith '.app'")
-        files = ((files as NSArray).filtered(using: predicate) as! [String])
-        return files[0]
+        return allFilesAt(path: folderPath)
+               .first(where: { URL(fileURLWithPath: $0).pathExtension == "app" })!
     }
 }
 


### PR DESCRIPTION
- gets rid of not needed NSPredicate;
- gets rid of not needed not toll free bridging Array to NSArray;
- uses URL, preferred way to work with path components in Swift;
- uses `first` instead of `filtered` then accessing first array element by 0 index, which is faster.