### PR TITLE
Fixed realm menu action

### DIFF
--- a/SimSim/Realm.swift
+++ b/SimSim/Realm.swift
@@ -125,7 +125,7 @@ class Realm: NSObject
                 break
             }
             
-            let folderPath = aPath + realmPath!
+            let folderPath = aPath + realmPath! + "/"
             
             let allFilesOfFolder = Tools.getSortedFiles(fromFolder: folderPath)
             

--- a/SimSim/Realm.swift
+++ b/SimSim/Realm.swift
@@ -5,8 +5,11 @@ import Cocoa
 class RealmFile: NSObject
 {
     var fileName = ""
-    var path = "" {
-      didSet {
+    var path = ""
+    {
+      didSet
+      {
+        // Make sure that path always ends with a slash
         if path.hasSuffix("/") == false {
           path += "/"
         }

--- a/SimSim/Realm.swift
+++ b/SimSim/Realm.swift
@@ -5,7 +5,13 @@ import Cocoa
 class RealmFile: NSObject
 {
     var fileName = ""
-    var path = ""
+    var path = "" {
+      didSet {
+        if path.hasSuffix("/") == false {
+          path += "/"
+        }
+      }
+    }
 
     //----------------------------------------------------------------------------
     func fullPath() -> String?
@@ -125,7 +131,7 @@ class Realm: NSObject
                 break
             }
             
-            let folderPath = aPath + realmPath! + "/"
+            let folderPath = aPath + realmPath!
             
             let allFilesOfFolder = Tools.getSortedFiles(fromFolder: folderPath)
             


### PR DESCRIPTION
**Issue:** 
Nothing happens if someone clicks on the realm menu-action:
![image](https://user-images.githubusercontent.com/4823365/46849680-f0c3a980-cdf0-11e8-9ef7-e210d5b7b20c.png)

**Actual problem in code:**
`RealmFile.fullPath()` returns something like this:
`/Users/halo/Library/Developer/CoreSimulator/Devices/BC12493D-1D2A-48EB-8245-CF8C6142F264/data/Containers/Data/Application/3A1D8D04-FFAB-471B-A6A6-8955E5A8B9B2/Documentsdefault.realm`
(the `/` after Documents is missing).


**Solution:**
Make sure that `RealmFile.path` always ends with a slash.