### PR TITLE
Fail gracefully when there are no simulators

### DIFF
--- a/SimSim/Menus.swift
+++ b/SimSim/Menus.swift
@@ -170,6 +170,13 @@ class Menus: NSObject
     {
         let menu = NSMenu()
         let simulators = Tools.activeSimulators()
+        
+        if simulators.isEmpty
+        {
+            let noSimulatorsItem = NSMenuItem(title: "No Simulators", action: nil, keyEquivalent: "")
+            noSimulatorsItem.isEnabled = false
+            menu.addItem(noSimulatorsItem)
+        }
 
         let recentSimulators = simulators.sorted { $0.date > $1.date }
         

--- a/SimSim/Tools.swift
+++ b/SimSim/Tools.swift
@@ -34,10 +34,10 @@ class Tools: NSObject
 
     
     //----------------------------------------------------------------------------
-    class func getSimulatorProperties() -> NSDictionary
+    class func getSimulatorProperties() -> NSDictionary?
     {
         let path = Tools.homeDirectoryPath() + "/Library/Preferences/com.apple.iphonesimulator.plist"
-        return NSDictionary(contentsOfFile: path)!
+        return NSDictionary(contentsOfFile: path)
     }
     
     //----------------------------------------------------------------------------
@@ -46,12 +46,12 @@ class Tools: NSObject
         let properties = getSimulatorProperties()
         var simulatorPaths = Set<String>()
         
-        if let currentSimulatorUuid = properties["CurrentDeviceUDID"] as? String
+        if let currentSimulatorUuid = properties?["CurrentDeviceUDID"] as? String
         {
             _ = simulatorPaths.insert(simulatorRootPath(byUUID: currentSimulatorUuid))
         }
         
-        if let devicePreferences = properties["DevicePreferences"] as? NSDictionary
+        if let devicePreferences = properties?["DevicePreferences"] as? NSDictionary
         {
             // we're running on xcode 9
             for uuid: NSString in devicePreferences.allKeys as! [NSString]


### PR DESCRIPTION
## What's in this PR?

#### Issue:

The application was crashing when there were no simulators installed, which can be the case on a freshly setup system. Even though this case seems very rare as using the application doesn't make too much sense without simulators not having it crash and instead showing an empty state seems to make sense.

#### Cause:

A force unwrap of the dictionary initialised with the simulator plist located at `/Library/Preferences/com.apple.iphonesimulator.plist` – which doesn't exists if there are no simulators yet – caused the application to crash.

#### Solution:

Don't force unwrap the optional dictionary and show a placeholder when there are no simulators at all.