### PR TITLE
Use real `menu` property of NSStatusItem to allow mouse pulldown

### DIFF
--- a/SimSim/AppDelegate.swift
+++ b/SimSim/AppDelegate.swift
@@ -35,22 +35,24 @@ extension AppDelegate: NSApplicationDelegate
         item.image = NSImage(named: "BarIcon")
         item.image?.isTemplate = true
         item.highlightMode = true
-        item.action = #selector(self.presentApplicationMenu)
         item.isEnabled = true
+
+        let menu = NSMenu()
+        menu.delegate = self
+        item.menu = menu
         
         statusItem = item
     }
+}
 
+//============================================================================
+extension AppDelegate: NSMenuDelegate
+{
     //----------------------------------------------------------------------------
-    @objc
-    func presentApplicationMenu()
-    {
-        let menu: NSMenu? = Menus.createApplicationMenu(at: statusItem!)
-        if let aMenu = menu
-        {
-            statusItem?.popUpMenu(aMenu)
-        }
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        Menus.updateApplicationMenu(menu, at: self.statusItem!)
     }
 }
+
 
 

--- a/SimSim/Menus.swift
+++ b/SimSim/Menus.swift
@@ -177,9 +177,10 @@ class Menus: NSObject
     }
     
     //----------------------------------------------------------------------------
-    class func createApplicationMenu(at statusItem: NSStatusItem) -> NSMenu
+    class func updateApplicationMenu(_ menu: NSMenu, at statusItem: NSStatusItem) -> Void
     {
-        let menu = NSMenu()
+        menu.removeAllItems()
+
         let simulators = Tools.activeSimulators()
         
         if simulators.isEmpty
@@ -212,7 +213,6 @@ class Menus: NSObject
         }
         menu.addItem(NSMenuItem.separator())
         addServiceItems(to: menu)
-        return menu
     }
 }
 


### PR DESCRIPTION
### The Problem

Using the `action` property of `NSStatusItem` to popup a menu doesn't allow holding down the left mouse button on the status bar item, moving it to a menu item, and releasing to select an item, as the user might expect.

### The Solution

Using the `menu` property of `NSStatusItem` allows it to be pulled down as expected, and using `NSMenu`'s `menuNeedsUpdate` delegate method allows the menu to still be updated when opened as before.