### PR TITLE
Removed Apple Podcasts app group

### DIFF
--- a/SimSim/Entities/AppGroup.swift
+++ b/SimSim/Entities/AppGroup.swift
@@ -18,7 +18,8 @@ class AppGroup
         return identifier.isEmpty ||
             identifier.starts(with: "com.apple") ||
             identifier.starts(with: "group.com.apple") ||
-            identifier.starts(with: "group.is.workflow")
+            identifier.starts(with: "group.is.workflow") ||
+            identifier.starts(with: "243LU875E5.groups.com.apple")
     }
 
     //----------------------------------------------------------------------------


### PR DESCRIPTION
With iOS 15 Simulator simsim show up this Podcast app

<img width="343" alt="image" src="https://user-images.githubusercontent.com/23437476/134390346-05cd88bf-ae7e-40fc-8507-0896e4138335.png">
